### PR TITLE
Add joystick-controlled triangle

### DIFF
--- a/.github/workflows/android-debug.yml
+++ b/.github/workflows/android-debug.yml
@@ -26,6 +26,8 @@ jobs:
         env:
           ANDROID_SDK_ROOT: /usr/local/lib/android/sdk
         run: |
+          echo "ANDROID_SDK_ROOT=${ANDROID_SDK_ROOT}"
+          ls -la "${ANDROID_SDK_ROOT}" || true
           set -u
           if [[ -x "${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager" ]]; then
             SDKMGR="${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager"
@@ -33,14 +35,19 @@ jobs:
             SDKMGR="$(ls -d "${ANDROID_SDK_ROOT}"/cmdline-tools/*/bin 2>/dev/null | head -n1)/sdkmanager"
           fi
           echo "Using sdkmanager at: ${SDKMGR}"
+          echo "sdkmanager version:"
+          "${SDKMGR}" --version || true
           yes | "${SDKMGR}" --licenses >/dev/null 2>&1 || true
           pkgs=("platform-tools" "platforms;android-34" "build-tools;34.0.0")
           for attempt in {1..3}; do
+            echo "Installing Android packages (attempt ${attempt})"
             "${SDKMGR}" --install "${pkgs[@]}" && ok=1 && break
             echo "sdkmanager failed (attempt ${attempt}); sleeping 10s and retrying..."
             sleep 10
           done
           [[ "${ok:-0}" == "1" ]] || { echo "sdkmanager failed after 3 attempts"; exit 1; }
+          echo "Installed packages:"
+          "${SDKMGR}" --list_installed || true
 
       - name: Setup Gradle cache
         uses: gradle/actions/setup-gradle@v4

--- a/app/src/main/java/com/example/helloworld/MainActivity.kt
+++ b/app/src/main/java/com/example/helloworld/MainActivity.kt
@@ -15,6 +15,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.*
 import androidx.compose.runtime.withFrameNanos
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
@@ -114,6 +115,7 @@ private fun GameScreen() {
     }
 }
 
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 private fun Joystick(
     modifier: Modifier = Modifier,

--- a/app/src/main/java/com/example/helloworld/MainActivity.kt
+++ b/app/src/main/java/com/example/helloworld/MainActivity.kt
@@ -47,6 +47,7 @@ class MainActivity : ComponentActivity() {
     }
 }
 
+@OptIn(ExperimentalComposeApi::class)
 @Composable
 private fun GameScreen() {
     val density = LocalDensity.current

--- a/app/src/main/java/com/example/helloworld/MainActivity.kt
+++ b/app/src/main/java/com/example/helloworld/MainActivity.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.*
+import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset

--- a/app/src/main/java/com/example/helloworld/MainActivity.kt
+++ b/app/src/main/java/com/example/helloworld/MainActivity.kt
@@ -3,23 +3,199 @@ package com.example.helloworld
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.isActive
+import kotlin.math.hypot
+import kotlin.math.roundToInt
+import kotlin.math.sqrt
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
             MaterialTheme {
-                Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                    Text(text = "Hello World")
+                Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
+                    GameScreen()
                 }
             }
         }
     }
+}
+
+@Composable
+private fun GameScreen() {
+    val density = LocalDensity.current
+    val triangleSide = 80.dp
+    val triangleSidePx = with(density) { triangleSide.toPx() }
+    val halfBase = triangleSidePx / 2f
+    val triangleHeight = triangleSidePx * sqrt(3f) / 2f
+    val topOffset = triangleHeight * 2f / 3f
+    val bottomOffset = triangleHeight / 3f
+
+    var containerSize by remember { mutableStateOf(IntSize.Zero) }
+    var triangleCenter by remember { mutableStateOf(Offset.Zero) }
+    var joystickInput by remember { mutableStateOf(Offset.Zero) }
+
+    LaunchedEffect(containerSize) {
+        if (containerSize != IntSize.Zero) {
+            triangleCenter = Offset(containerSize.width / 2f, containerSize.height / 2f)
+        }
+    }
+
+    LaunchedEffect(containerSize) {
+        if (containerSize == IntSize.Zero) return@LaunchedEffect
+        var lastTimestamp = 0L
+        while (isActive) {
+            withFrameNanos { timestamp ->
+                if (lastTimestamp != 0L) {
+                    val deltaSeconds = (timestamp - lastTimestamp) / 1_000_000_000f
+                    val speed = 500f
+                    val input = joystickInput
+                    val delta = Offset(input.x * speed * deltaSeconds, input.y * speed * deltaSeconds)
+                    val proposedCenter = triangleCenter + delta
+                    triangleCenter = proposedCenter.coerceWithin(
+                        minX = halfBase,
+                        maxX = containerSize.width - halfBase,
+                        minY = topOffset,
+                        maxY = containerSize.height - bottomOffset
+                    )
+                }
+                lastTimestamp = timestamp
+            }
+        }
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color(0xFF101010))
+            .onGloballyPositioned { layoutCoordinates ->
+                containerSize = layoutCoordinates.size
+            }
+    ) {
+        Canvas(modifier = Modifier.fillMaxSize()) {
+            if (containerSize != IntSize.Zero && triangleCenter != Offset.Zero) {
+                drawTriangle(center = triangleCenter, side = triangleSidePx, color = Color.Red)
+            }
+        }
+
+        Joystick(
+            modifier = Modifier
+                .align(Alignment.BottomStart)
+                .padding(start = 24.dp, bottom = 24.dp),
+            onOffsetChanged = { joystickInput = it }
+        )
+    }
+}
+
+@Composable
+private fun Joystick(
+    modifier: Modifier = Modifier,
+    radius: Dp = 80.dp,
+    onOffsetChanged: (Offset) -> Unit
+) {
+    val density = LocalDensity.current
+    val radiusPx = with(density) { radius.toPx() }
+    val knobRadiusDp = radius * 0.5f
+    var knobPosition by remember { mutableStateOf(Offset.Zero) }
+
+    Box(
+        modifier = modifier
+            .size(radius * 2)
+            .pointerInput(radiusPx) {
+                detectDragGestures(
+                    onDragStart = { offset ->
+                        val relative = offset - Offset(radiusPx, radiusPx)
+                        knobPosition = relative.coerceInCircle(radiusPx)
+                        onOffsetChanged(knobPosition.normalized(radiusPx))
+                    },
+                    onDrag = { change, dragAmount ->
+                        change.consume()
+                        val newPosition = knobPosition + Offset(dragAmount.x, dragAmount.y)
+                        knobPosition = newPosition.coerceInCircle(radiusPx)
+                        onOffsetChanged(knobPosition.normalized(radiusPx))
+                    },
+                    onDragEnd = {
+                        knobPosition = Offset.Zero
+                        onOffsetChanged(Offset.Zero)
+                    },
+                    onDragCancel = {
+                        knobPosition = Offset.Zero
+                        onOffsetChanged(Offset.Zero)
+                    }
+                )
+            }
+    ) {
+        Canvas(modifier = Modifier.fillMaxSize()) {
+            drawCircle(color = Color.White.copy(alpha = 0.2f), radius = radiusPx)
+        }
+
+        Box(
+            modifier = Modifier
+                .size(knobRadiusDp * 2)
+                .align(Alignment.Center)
+                .offset { IntOffset(knobPosition.x.roundToInt(), knobPosition.y.roundToInt()) }
+                .background(Color.White.copy(alpha = 0.5f), CircleShape)
+        )
+    }
+}
+
+private fun DrawScope.drawTriangle(center: Offset, side: Float, color: Color) {
+    val halfBase = side / 2f
+    val height = side * sqrt(3f) / 2f
+    val path = Path().apply {
+        val top = Offset(center.x, center.y - (2f * height / 3f))
+        val bottomLeft = Offset(center.x - halfBase, center.y + height / 3f)
+        val bottomRight = Offset(center.x + halfBase, center.y + height / 3f)
+        moveTo(top.x, top.y)
+        lineTo(bottomLeft.x, bottomLeft.y)
+        lineTo(bottomRight.x, bottomRight.y)
+        close()
+    }
+    drawPath(path = path, color = color)
+}
+
+private fun Offset.coerceInCircle(radius: Float): Offset {
+    val distance = hypot(x, y)
+    return if (distance > radius) {
+        val scale = radius / distance
+        Offset(x * scale, y * scale)
+    } else {
+        this
+    }
+}
+
+private fun Offset.coerceWithin(minX: Float, maxX: Float, minY: Float, maxY: Float): Offset {
+    val clampedX = x.coerceIn(minX, maxX)
+    val clampedY = y.coerceIn(minY, maxY)
+    return Offset(clampedX, clampedY)
+}
+
+private fun Offset.normalized(radius: Float): Offset {
+    if (radius == 0f) return Offset.Zero
+    return Offset(x / radius, y / radius)
 }
 

--- a/app/src/main/java/com/example/helloworld/MainActivity.kt
+++ b/app/src/main/java/com/example/helloworld/MainActivity.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.offset
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp

--- a/app/src/main/java/com/example/helloworld/MainActivity.kt
+++ b/app/src/main/java/com/example/helloworld/MainActivity.kt
@@ -23,7 +23,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.layout.offset
+import androidx.compose.foundation.layout.offset
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp


### PR DESCRIPTION
## Summary
- replace the hello world placeholder with a composable game screen and joystick UI
- render a red player triangle that responds to joystick input while clamped to the screen bounds

## Testing
- ./gradlew :app:assembleDebug *(fails: Android SDK not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ea5a274ffc832891ac92d2b1213f0d